### PR TITLE
Handle git subtree pull failures for template-based projects

### DIFF
--- a/.github/workflows/check-charter.yml
+++ b/.github/workflows/check-charter.yml
@@ -109,10 +109,8 @@ jobs:
             git archive dev-charter/main | tar -x -C "${PREFIX}/"
             git add "${PREFIX}/"
 
-            git commit -m "Squashed '${PREFIX}/' content from commit ${SPLIT}
-
-git-subtree-dir: ${PREFIX}
-git-subtree-split: ${SPLIT}"
+            git commit -m "$(printf "Squashed '%s/' content from commit %s\n\ngit-subtree-dir: %s\ngit-subtree-split: %s" \
+              "${PREFIX}" "${SPLIT}" "${PREFIX}" "${SPLIT}")"
           fi
 
           git push origin "${BRANCH}" --force-with-lease

--- a/.github/workflows/check-charter.yml
+++ b/.github/workflows/check-charter.yml
@@ -93,11 +93,27 @@ jobs:
 
           git checkout -B "${BRANCH}" origin/main
 
-          git subtree pull \
-            --prefix="${PREFIX}" \
-            dev-charter main \
-            --squash \
-            -m "chore: update dev-charter to ${REMOTE}"
+          if ! git subtree pull \
+              --prefix="${PREFIX}" \
+              dev-charter main \
+              --squash \
+              -m "chore: update dev-charter to ${REMOTE}"; then
+            # Fallback: template project (no subtree history)
+            # Clean up any partial state from the failed attempt
+            git reset --hard HEAD
+            git clean -fd "${PREFIX}/"
+
+            SPLIT=$(git rev-parse dev-charter/main)
+            git rm -rf "${PREFIX}/"
+            mkdir -p "${PREFIX}"
+            git archive dev-charter/main | tar -x -C "${PREFIX}/"
+            git add "${PREFIX}/"
+
+            git commit -m "Squashed '${PREFIX}/' content from commit ${SPLIT}
+
+git-subtree-dir: ${PREFIX}
+git-subtree-split: ${SPLIT}"
+          fi
 
           git push origin "${BRANCH}" --force-with-lease
 

--- a/README-jp.md
+++ b/README-jp.md
@@ -67,6 +67,23 @@ git remote add dev-charter https://github.com/y-marui/dev-charter
 git subtree pull --prefix=docs/dev-charter dev-charter main --squash
 ```
 
+> **Note（テンプレートリポジトリから作成したプロジェクト）:**
+> GitHub テンプレートはファイルのみコピーし git 履歴を引き継がないため、`git subtree pull` は失敗します。
+> `check-charter.yml` ワークフローがこのケースを自動検出して対処します。
+> 手動で更新する場合は `git subtree pull` の代わりに以下を実行してください：
+> ```bash
+> git remote add dev-charter https://github.com/y-marui/dev-charter || true
+> git fetch dev-charter
+> SPLIT=$(git rev-parse dev-charter/main)
+> git rm -rf docs/dev-charter/
+> git archive dev-charter/main | tar -x -C docs/dev-charter/
+> git add docs/dev-charter/
+> git commit -m "Squashed 'docs/dev-charter/' content from commit ${SPLIT}
+>
+> git-subtree-dir: docs/dev-charter
+> git-subtree-split: ${SPLIT}"
+> ```
+
 更新後、以下のプロンプトを AI ツールに貼り付けてください：
 
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,23 @@ git remote add dev-charter https://github.com/y-marui/dev-charter
 git subtree pull --prefix=docs/dev-charter dev-charter main --squash
 ```
 
+> **Note (projects created from a template repository):**
+> GitHub templates copy files only — git history is not carried over — so `git subtree pull` will fail.
+> The `check-charter.yml` workflow detects this automatically and handles it.
+> For manual updates, use the following instead of `git subtree pull`:
+> ```bash
+> git remote add dev-charter https://github.com/y-marui/dev-charter || true
+> git fetch dev-charter
+> SPLIT=$(git rev-parse dev-charter/main)
+> git rm -rf docs/dev-charter/
+> git archive dev-charter/main | tar -x -C docs/dev-charter/
+> git add docs/dev-charter/
+> git commit -m "Squashed 'docs/dev-charter/' content from commit ${SPLIT}
+>
+> git-subtree-dir: docs/dev-charter
+> git-subtree-split: ${SPLIT}"
+> ```
+
 After updating, paste the following prompt into your AI tool:
 
 ```

--- a/topics/TEMPLATE_README_GUIDELINES.md
+++ b/topics/TEMPLATE_README_GUIDELINES.md
@@ -240,3 +240,9 @@ README 作成後、以下を確認する。
 7. AI 対応の場合は `AI_CONTEXT.md`・`CLAUDE.md`・`GEMINI.md` を作成する
 8. `.github/copilot-instructions.md` を作成する（Copilot 使用時）
 9. GitHub 公開プロジェクトの場合は `.github/FUNDING.yml` を作成する（[MONETIZATION_POLICY.md](../MONETIZATION_POLICY.md) 参照）
+
+> **Note（dev-charter を含むテンプレートの場合）:**
+> GitHub テンプレートはファイルのみコピーし git 履歴を引き継がないため、
+> テンプレートから作成したプロジェクトでは `git subtree pull` による dev-charter 更新が失敗する。
+> `check-charter.yml` ワークフローがこのケースを自動検出して対処するため、手動対応は不要。
+> 手動更新が必要な場合は [README-jp.md](../README-jp.md) の **Update** セクションを参照。


### PR DESCRIPTION
## Summary
Add fallback handling for `git subtree pull` failures in projects created from GitHub templates, which don't carry over git history. The workflow now automatically detects and handles this case, and documentation has been updated to guide users.

## Key Changes
- **Workflow enhancement** (`check-charter.yml`): Wrapped `git subtree pull` in a conditional that falls back to `git archive` + manual commit when subtree pull fails. This handles projects created from templates where git history isn't available.
- **Documentation updates** (README.md, README-jp.md): Added notes explaining why `git subtree pull` fails for template-based projects and provided manual update instructions as an alternative.
- **Guidelines update** (TEMPLATE_README_GUIDELINES.md): Added a note clarifying that the workflow handles this case automatically and no manual intervention is needed.

## Implementation Details
The fallback mechanism:
1. Attempts the standard `git subtree pull` command
2. On failure, cleans up any partial state from the failed attempt
3. Uses `git archive` to extract the remote content without history
4. Creates a commit with metadata matching git-subtree format (includes `git-subtree-dir` and `git-subtree-split` markers) for consistency

This approach ensures that projects created from GitHub templates can still receive dev-charter updates through the automated workflow without requiring manual intervention.

https://claude.ai/code/session_016XHTwANfgF1oi7ro3zzTQE