### PR TITLE
Exclude merge commits from version date check in CI

### DIFF
--- a/scripts/check-version-date.sh
+++ b/scripts/check-version-date.sh
@@ -1,14 +1,14 @@
 #!/usr/bin/env bash
-# Check (or update) VERSION to match today's date (local) or the last commit date (CI).
+# Check (or update) VERSION to match today's date (local) or the last non-merge commit date (CI).
 #
 # Usage:
 #   pre-commit run check-version-date            # local: compares to today
-#   CI=1 pre-commit run --all-files              # CI: compares to git log -1 date
+#   CI=1 pre-commit run --all-files              # CI: compares to git log -1 --no-merges date
 #   UPDATE=1 bash scripts/check-version-date.sh  # write expected date to VERSION
 set -euo pipefail
 
 if [ -n "${CI:-}" ]; then
-  EXPECTED=$(git log -1 --format="%ad" --date=format:"%Y-%m-%d")
+  EXPECTED=$(git log -1 --no-merges --format="%ad" --date=format:"%Y-%m-%d")
 else
   EXPECTED=$(date +%Y-%m-%d)
 fi


### PR DESCRIPTION
## Summary
Updated the version date checking script to ignore merge commits when determining the expected date in CI environments. This ensures the version date is based on actual code changes rather than merge commits.

## Changes
- Modified `git log` command to include `--no-merges` flag when running in CI mode
- Updated documentation comments to reflect that CI now uses the last non-merge commit date instead of the last commit date

## Details
The script now uses `git log -1 --no-merges` in CI environments to fetch the date of the most recent non-merge commit. This prevents merge commits from affecting the version date validation, ensuring the version consistently reflects actual development work rather than repository maintenance operations.

https://claude.ai/code/session_01WcpP7KBQLzoLXYu1J2WkGk