### PR TITLE
feat: create update-charter PR as Draft with gh pr ready instructions

### DIFF
--- a/.github/workflows/check-charter.yml
+++ b/.github/workflows/check-charter.yml
@@ -123,15 +123,33 @@ jobs:
           gh pr create \
             --title "chore: update dev-charter to ${REMOTE}" \
             --body "$(cat <<EOF
+          ## Update dev-charter to ${REMOTE}
+
+          \`git subtree pull\` has been applied automatically.
+          This PR is a **Draft**. Complete the following steps, then mark it as ready:
+
+          1. Open \`docs/dev-charter/UPDATE_CHECKLIST.md\` and paste its contents into your AI tool to apply the changes.
+          2. Review and commit the changes.
+          3. Run \`gh pr ready\` to remove the Draft status.
+
+          > To review all charter files (not just changed ones), use \`docs/dev-charter/INSTALL_CHECKLIST.md\`.
+
+          ---
+
           ## dev-charter を ${REMOTE} に更新
 
           \`git subtree pull\` を自動的に適用しました。
-          マージ後、\`docs/dev-charter/UPDATE_CHECKLIST.md\` に従って変更のあった箇所を対応してください。
+          この PR は **Draft** です。以下の手順を完了してから Draft を解除してください：
+
+          1. \`docs/dev-charter/UPDATE_CHECKLIST.md\` の内容を AI ツールに貼り付けて対応を実行する
+          2. 変更をレビュー・コミットする
+          3. \`gh pr ready\` を実行して Draft を解除する
 
           > 全ファイルを網羅的に確認したい場合は \`docs/dev-charter/INSTALL_CHECKLIST.md\` を使用してください。
           EOF
           )" \
             --base main \
             --head update-charter \
-            --label "dev-charter" || \
+            --label "dev-charter" \
+            --draft || \
             gh pr list --head update-charter --base main --json number --jq length | grep -q '^[1-9]'


### PR DESCRIPTION
## Summary

- `check-charter.yml` の `gh pr create` に `--draft` フラグを追加し、チェックリスト対応前のマージを防ぐ
- PR 本文を英日二言語で更新：Draft であること・`UPDATE_CHECKLIST.md` の手順・`gh pr ready` での解除を明記
- `UPDATE_CHECKLIST.md` は汎用ドキュメントなので変更なし

## Test plan

- [x] バージョン差分を作ってワークフローをトリガーし、作成された PR が Draft 状態であることを確認
- [x] PR 本文に `gh pr ready` の手順が含まれていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)